### PR TITLE
Fixes #11 new version 1.7 catches NPE when calling platform function …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.athento.nuxeo.listeners</groupId>
   <artifactId>nuxeo-metadata-change-listener-plugin</artifactId>
-  <version>1.6</version>
+  <version>1.7</version>
   <name>nuxeo-metadata-change-listener-plugin</name>
   <description/>
   <dependencyManagement>

--- a/src/main/java/org/athento/nuxeo/listener/MetadataValueChangeListener.java
+++ b/src/main/java/org/athento/nuxeo/listener/MetadataValueChangeListener.java
@@ -336,7 +336,7 @@ public class MetadataValueChangeListener implements EventListener {
 					MetadataValueChangeListener.BUNDLE_NAME, valueLabel, 
 					MetadataValueChangeListener.EMPTY_ARRAY, 
 					locale);
-			} catch (DirectoryException e) {
+			} catch (Throwable e) {
 				_log.error("Unable to get Directory with name: " + keyVocabularyName,e);
 				_log.error("Returning value: " + value);
 				translatedValue = String.valueOf(value);


### PR DESCRIPTION
…getVocabularyLabel
